### PR TITLE
fix: use channels

### DIFF
--- a/anonip.go
+++ b/anonip.go
@@ -71,7 +71,6 @@ func getIPStrings(line string, columns []uint) []string {
 	ipList := []string{}
 	for _, column := range columns {
 		if int(column) > len(logList)-1 {
-			// uncovered
 			continue
 		}
 		ipList = append(ipList, logList[column])

--- a/anonip.go
+++ b/anonip.go
@@ -78,11 +78,15 @@ func getIPStrings(line string, columns []uint) []string {
 	return ipList
 }
 
-func printLog(w io.Writer, line []byte) {
-	w.Write(line)
+func printLog(w io.Writer, line string) {
+	w.Write([]byte(line + "\n"))
 }
 
-func handleLine(line string, args Args) string {
+func handleLine(line string, args Args, channel chan string) {
+	if line == "" {
+		channel <- line
+		return
+	}
 	ipStrings := getIPStrings(line, args.Columns)
 	for _, ipString := range ipStrings {
 		ipString, ip := getIP(ipString)
@@ -95,8 +99,7 @@ func handleLine(line string, args Args) string {
 		}
 		line = strings.ReplaceAll(line, ipString, maskedIp.String())
 	}
-	printLog(logWriter, []byte(line+"\n"))
-	return line
+	channel <- line
 }
 
 type Args struct {
@@ -129,9 +132,11 @@ func parseArgs() (Args, *arg.Parser, error) {
 }
 
 func run(args Args) {
+	channel := make(chan string)
 	scanner := bufio.NewScanner(logReader)
 	for scanner.Scan() {
-		go handleLine(scanner.Text(), args)
+		go handleLine(scanner.Text(), args, channel)
+		printLog(logWriter, <-channel)
 	}
 	if err := scanner.Err(); err != nil {
 		log.Println(err)

--- a/anonip_test.go
+++ b/anonip_test.go
@@ -168,12 +168,19 @@ func TestHandleLine(t *testing.T) {
 			V4Mask:   12,
 			V6Mask:   84,
 		},
+		{
+			Input:    "",
+			Expected: "",
+			V4Mask:   12,
+			V6Mask:   84,
+		},
 	}
 
 	for _, tCase := range testMap {
+		channel := make(chan string)
 		args := Args{IpV4Mask: tCase.V4Mask, IpV6Mask: tCase.V6Mask, Columns: []uint{0}}
-		maskedLine := handleLine(tCase.Input, args)
-		if maskedLine != tCase.Expected {
+		go handleLine(tCase.Input, args, channel)
+		if maskedLine := <-channel; maskedLine != tCase.Expected {
 			t.Errorf("Failing input: %+v\nReceived output: %v", tCase, maskedLine)
 		}
 	}
@@ -198,9 +205,10 @@ func TestIncrement(t *testing.T) {
 		},
 	}
 	for _, tCase := range testMap {
+		channel := make(chan string)
 		args := Args{Increment: tCase.Increment, IpV4Mask: 12, IpV6Mask: 84, Columns: []uint{0}}
-		maskedLine := handleLine(tCase.Input, args)
-		if maskedLine != tCase.Expected {
+		go handleLine(tCase.Input, args, channel)
+		if maskedLine := <-channel; maskedLine != tCase.Expected {
 			t.Errorf("Failing input: %+v\nReceived output: %v", tCase, maskedLine)
 		}
 	}
@@ -240,9 +248,10 @@ func TestColumns(t *testing.T) {
 		},
 	}
 	for _, tCase := range testMap {
+		channel := make(chan string)
 		args := Args{Columns: tCase.Columns, IpV4Mask: 12, IpV6Mask: 84}
-		maskedLine := handleLine(tCase.Input, args)
-		if maskedLine != tCase.Expected {
+		go handleLine(tCase.Input, args, channel)
+		if maskedLine := <-channel; maskedLine != tCase.Expected {
 			t.Errorf("Failing input: %+v\nReceived output: %v", tCase, maskedLine)
 		}
 	}


### PR DESCRIPTION
This commit implements using channels instead of plain  go routines.
This fixes several things at once:

 - It will ensure that the order of input is preserved
 - It allows for echoing into anonip (`echo "3.3.3.3" | go run
   ./anonip.go`). Somehow this failed before while cat was working(?)

Additionally, this commit prevents empty line from being processed.